### PR TITLE
Add SortFieldsMap helper

### DIFF
--- a/sorters/sorters.go
+++ b/sorters/sorters.go
@@ -80,6 +80,16 @@ func SortFields(nodes []*ast.FieldDefinition) {
 	})
 }
 
+// SortFieldsMap will sort a map of fields by name and return a newly created slice.
+func SortFieldsMap(nodes []*ast.FieldDefinition) []*ast.FieldDefinition {
+	var fields []*ast.FieldDefinition
+	for _, one := range nodes {
+		fields = append(fields, one)
+	}
+	SortFields(fields)
+	return fields
+}
+
 // ------------
 // object types
 


### PR DESCRIPTION
Sometimes you have a map of fields and you'd like them to be sorted (like in [bagger](https://github.com/Fanatics/graphql-ast-helpers/blob/master/bagger/bagger.go#L201-L214)), this adds a helper to do that.

